### PR TITLE
feat: add documentation and improve ansible integration for centos 8 packer build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vagrant/**/.vagrant/
+packer/**/packer_cache/
+packer/**/output-**-vbox/

--- a/packer/centos/README.md
+++ b/packer/centos/README.md
@@ -1,0 +1,14 @@
+# Create a CentOS Stream 8 image
+## Overview
+Utilizes Packer and Ansible to create a CentOS Stream 8 image. 
+
+## Usage
+1. The entire cloned respository must be available as the `centos.pkr.hcl` references the ansible folder for provisioning customizations.
+1. As the CentOS Stream ISO names change (rolling release) you will need to identify the currently available release at the mirror of your preference and update the `iso_url` variable
+1. Update the `rootpw` in the `ks_centos8.cfg` file to your preference as well as the `user` definition and password
+1. Build the template with with `packer build -force -var 'ssh_password=YourUserPassword' -var 'ssh_username=YouUserName' .`
+  * ssh_username is the `user` you created in the `ks_centos8.cfg`
+  * ssh_password is the password for the `user` you created in `ks_centos8.cfg`
+
+## Notes
+Encrypting the password for the Kickstart file `ks_centos8.cfg` can be done using the example Python script `encryptme.py`

--- a/packer/centos/centos8.pkr.hcl
+++ b/packer/centos/centos8.pkr.hcl
@@ -38,13 +38,10 @@ build {
     ]
   }
 
-  provisioner "file" {
-    source      = "../../ansible"
-    destination = "/tmp"
-  }
-
   provisioner "ansible-local" {
-    playbook_file   = "/tmp/ansible/workstation-playbook.yml"
-    extra_arguments = ["--extra-vars", "\"ansible_become_password=${var.ssh_password}\""]
+    playbook_dir            = "../../ansible"
+    playbook_file           = "../../ansible/workstation-playbook.yml"
+    extra_arguments         = ["--extra-vars", "\"ansible_become_password=${var.ssh_password}\""]
+    clean_staging_directory = true
   }
 }

--- a/packer/centos/scripts/encryptme.py
+++ b/packer/centos/scripts/encryptme.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+'''
+Encrypts the entered password for use in the Kickstart configuration
+
+Doc: https://docs.centos.org/en-US/8-docs/advanced-install/assembly_kickstart-commands-and-options-reference/#rootpw-required_kickstart-commands-for-system-configuration
+'''
+
+import crypt
+import getpass 
+
+password=getpass.getpass()
+print(crypt.crypt(password) if (password==getpass.getpass("Confirm: ")) else exit())


### PR DESCRIPTION
# Changes
* change the way Packer uses the ansible-local provisioner by specifying the playbook_dir which copies the ansible files automatically
* add documentation on how to build the image using packer
* add a script to encrypt passwords for use in the KickStart file
* exclude packer cache and output files from git