### PR TITLE
chore: update centos stream iso and corrected packer hcl2 formatting

### DIFF
--- a/packer/centos/centos8.pkr.hcl
+++ b/packer/centos/centos8.pkr.hcl
@@ -3,29 +3,29 @@ source "virtualbox-iso" "centos8-vbox" {
   guest_os_type        = "RedHat_64"
   guest_additions_mode = "attach"
 
-  iso_url              = var.iso_url
-  iso_checksum         = var.iso_checksum
-  http_directory       = var.http_directory
+  iso_url        = var.iso_url
+  iso_checksum   = var.iso_checksum
+  http_directory = var.http_directory
 
-  communicator         = "ssh"
-  ssh_timeout          = "30m"
-  ssh_username         = var.ssh_username
-  ssh_password         = var.ssh_password
+  communicator = "ssh"
+  ssh_timeout  = "30m"
+  ssh_username = var.ssh_username
+  ssh_password = var.ssh_password
 
   cpus                 = var.cpus
   memory               = var.memory
   disk_size            = var.disk_size
   hard_drive_interface = "sata"
 
-  boot_wait            = "5s"
-  boot_command         = [
+  boot_wait = "5s"
+  boot_command = [
     "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/${var.ks_path}<enter><wait>"
   ]
 
-  shutdown_command     = "echo ${var.ssh_password} | sudo -S shutdown -P now"
-  shutdown_timeout     = "5m"
-  skip_export          = true
-  keep_registered      = true
+  shutdown_command = "echo ${var.ssh_password} | sudo -S shutdown -P now"
+  shutdown_timeout = "5m"
+  skip_export      = true
+  keep_registered  = true
 }
 
 build {

--- a/packer/centos/variables.auto.pkrvars.hcl
+++ b/packer/centos/variables.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 vm_name        = "vbw-centos8"
-iso_url        = "http://ftp.usf.edu/pub/centos/8-stream/isos/x86_64/CentOS-Stream-8-x86_64-20210126-boot.iso"
+iso_url        = "http://ftp.usf.edu/pub/centos/8-stream/isos/x86_64/CentOS-Stream-8-x86_64-20210209-boot.iso"
 iso_checksum   = "file:http://ftp.usf.edu/pub/centos/8-stream/isos/x86_64/CHECKSUM"
 ssh_username   = "agayle"
 cpus           = 1

--- a/packer/centos/variables.pkr.hcl
+++ b/packer/centos/variables.pkr.hcl
@@ -3,27 +3,27 @@ variable "vm_name" {
 }
 
 variable "iso_url" {
-  type = string
+  type    = string
   default = "http://ftp.usf.edu/pub/centos/8-stream/isos/x86_64/CentOS-Stream-8-x86_64-20210126-boot.iso"
 }
 
 variable "iso_checksum" {
-  type = string
+  type    = string
   default = "file:http://ftp.usf.edu/pub/centos/8-stream/isos/x86_64/CHECKSUM"
 }
 
 variable "ssh_username" {
-  type = string
+  type    = string
   default = "agayle"
 }
 
 variable "ssh_password" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "cpus" {
-  type = number
+  type    = number
   default = 1
 }
 
@@ -40,11 +40,11 @@ variable "disk_size" {
 }
 
 variable "http_directory" {
-  type = string
+  type    = string
   default = "./http"
 }
 
 variable "ks_path" {
-  type = string
+  type    = string
   default = "ks_centos8.cfg"
 }


### PR DESCRIPTION
# Description

* Updated the CentOS Stream 8 iso download path
* Corrected the Packer file HCL2 formatting to pass validation

# Testing methods

* Verified the download path worked
* Ran `packer fmt --check`

- [x] Download path verified with `wget`
- [x] HCL2 formatting checked with `packer fmt --check`

# Checklist:

- [x] The code follows the style guidelines of this project
- [x] The code has been self-reviewed
- [x] The code has been commented, particularly in hard-to-understand areas
- [x] The documentation has updated
- [x] There are no new warnings generated

**Please remove any instructional text before submitting the pull request**

