### PR TITLE
feat: initial terraform tutorial for certification practice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vagrant/**/.vagrant/
 packer/**/packer_cache/
 packer/**/output-**-vbox/
+terraform/**/.terraform/
+terraform.tfstate*

--- a/terraform/certification/docker/.terraform.lock.hcl
+++ b/terraform/certification/docker/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/kreuzwerker/docker" {
+  version     = "2.13.0"
+  constraints = ">= 2.13.0"
+  hashes = [
+    "h1:3r/gPhfPCl4mxazpfg0S/qgxmt+QWuvYT3CXTxUz9fs=",
+    "zh:0df685adc7b5740ae0def7235a44e1bce2f71beaf155319c2464ad2fba5cb321",
+    "zh:2cf4b4f840fa84f1b906f4cca58c9782375e9988ad354afcd85b0180cd784205",
+    "zh:347b189655afdc0df1919a26fb64cb745bb02d8fa2006a087cb6679a1b62319d",
+    "zh:441521c85fecad348ca012db7b9d14544cbe0a237012f8a03d5660c73e9a32a6",
+    "zh:462a1f67d26182fbb5ee78bb8d4764a2983804fa5f9971ca006da439e9e97055",
+    "zh:53822eb743cd487cabbed3360221cc0404b80f933b746d80426a4e10fa2f958a",
+    "zh:55c6eda01dd3d3f877aad16de6bf91e84bfa9c93f852869581429640be19d472",
+    "zh:690bb327398f800f7945bab35b1ad2c6ec1c0fa7f8a1e5696b0bc4597540e3af",
+    "zh:6c55a9a761596ca974a9cbaeee3179fb8f50916fad18d2422a2d818c3f4dc241",
+    "zh:6efd9e6ffa4c4c73fd39c856456022aad6a3a0b176c550409345e894475bbf4f",
+    "zh:811a37e3a66d5e99a81e0e66c817363205b030962fcec68bb96ab53b029ffeac",
+    "zh:aacb4ab8dd11e834952877390bc19beabf9fb0591c101e96da559201f4b284ca",
+    "zh:cecdf49f9488a10ac9416be354e7de3ed45114a25235cebc4ec6771696d980e9",
+  ]
+}

--- a/terraform/certification/docker/main.tf
+++ b/terraform/certification/docker/main.tf
@@ -1,0 +1,15 @@
+resource "docker_image" "nginx" {
+  name = "nginx:stable"
+}
+
+resource "docker_container" "web" {
+  image   = docker_image.nginx.latest
+  name    = "web"
+  restart = "on-failure"
+  rm      = false
+
+  ports {
+    internal = 80
+    external = 8080
+  }
+}

--- a/terraform/certification/docker/provider.tf
+++ b/terraform/certification/docker/provider.tf
@@ -1,0 +1,3 @@
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}

--- a/terraform/certification/docker/versions.tf
+++ b/terraform/certification/docker/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = ">= 2.13.0"
+    }
+  }
+}


### PR DESCRIPTION
# Preparation for the Terraform Associate Certification

* Create a basic docker deployment to test the installation of `terraform`

# Testing methods

* Terraform provides the tests using `fmt` and `validate` options

- [X] fmt
- [X] validate

# Checklist:

- [X] The code follows the style guidelines of this project
- [X] The code has been self-reviewed
- [X] The code has been commented, particularly in hard-to-understand areas
- [X] The documentation has updated
- [X] There are no new warnings generated

# Todo
* Add github action to automatically check lint and validate as well as run a plan