### PR TITLE
feat (terraform): add module, for and for_each examples using pets

### DIFF
--- a/terraform/certification/pets/.terraform.lock.hcl
+++ b/terraform/certification/pets/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.0"
+  constraints = ">= 3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/terraform/certification/pets/.tool-versions
+++ b/terraform/certification/pets/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.0.11

--- a/terraform/certification/pets/main.tf
+++ b/terraform/certification/pets/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = "~> 1.0.0"
+
+  backend "remote" {
+    organization = "wec-acme-inc"
+
+    workspaces {
+      name = "pets-saga"
+    }
+  }
+}
+
+module "dog" {
+  source = "./modules/pet-generator"
+
+  pet_prefix = var.single_pet_prefix
+}
+
+module "famous_dogs_enhanced" {
+  source = "./modules/pet-generator"
+
+  for_each   = var.famous_dogs_prefix
+  pet_prefix = each.key
+}
+
+module "large_dogs" {
+  source = "./modules/pet-generator"
+
+  for_each   = { for key, value in var.dogs : key => value if value == "large" }
+  pet_prefix = each.key
+}

--- a/terraform/certification/pets/modules/pet-generator/README.md
+++ b/terraform/certification/pets/modules/pet-generator/README.md
@@ -1,0 +1,11 @@
+# Pets Generator
+This is the cheapest way I could find to prepare for the Terraform Associate 
+Certification without generating a Cloud Provider bill. Technically this is 
+not a very representative module as it is a single resource.
+
+## Variables
+* pet_prefex: The first name of the pet we are generating a last name for
+
+## Outputs
+* pet_name: The name of the pet automatically generated. Some are actually 
+entertaining.

--- a/terraform/certification/pets/modules/pet-generator/main.tf
+++ b/terraform/certification/pets/modules/pet-generator/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
+    }
+  }
+}
+
+resource "random_pet" "pet_name" {
+  prefix    = var.pet_prefix
+  length    = 1
+  separator = " "
+}

--- a/terraform/certification/pets/modules/pet-generator/outputs.tf
+++ b/terraform/certification/pets/modules/pet-generator/outputs.tf
@@ -1,0 +1,4 @@
+output "pet_name" {
+  description = "Automatically generated pet name."
+  value       = random_pet.pet_name.id
+}

--- a/terraform/certification/pets/modules/pet-generator/variables.tf
+++ b/terraform/certification/pets/modules/pet-generator/variables.tf
@@ -1,0 +1,4 @@
+variable "pet_prefix" {
+  description = "The first name of the pet."
+  type        = string
+}

--- a/terraform/certification/pets/outputs.tf
+++ b/terraform/certification/pets/outputs.tf
@@ -1,0 +1,14 @@
+output "dog_name" {
+  description = "The generated dog name from a prefix."
+  value       = title(module.dog.pet_name)
+}
+
+output "famous_names" {
+  description = "The names of famous dogs."
+  value       = [for key, value in module.famous_dogs_enhanced : title(value.pet_name)]
+}
+
+output "large_dog_names" {
+  description = "The names of some large dogs."
+  value       = [for key, value in module.large_dogs : title(value.pet_name)]
+}

--- a/terraform/certification/pets/variables.tf
+++ b/terraform/certification/pets/variables.tf
@@ -1,0 +1,27 @@
+variable "single_pet_prefix" {
+  description = "Prefix for the name of a single pet."
+  type        = string
+  default     = "Rover"
+}
+
+variable "famous_dogs_prefix" {
+  description = "Prefix using famous dog names."
+  type        = set(string)
+  default = [
+    "Clifford",
+    "Lassie",
+    "Bolt",
+    "Beethoven"
+  ]
+}
+
+variable "dogs" {
+  description = "Map of dogs and their sizes."
+  type        = map(string)
+  default = {
+    "German Shepard" = "large"
+    "Saint Bernard"  = "large"
+    "Fox Terrier"    = "small"
+    "Chihuahua"      = "small"
+  }
+}


### PR DESCRIPTION
# Description

* Add a pet name generation module
* Add examples using the pet generation module
* Use Terraform Cloud as backend

# Testing methods

- [X] terraform plan
- [X] terraform validate

# Checklist:

- [X] The code follows the style guidelines of this project
- [X] The code has been self-reviewed
- [X] The code has been commented, particularly in hard-to-understand areas
- [X] The documentation has updated
- [X] There are no new warnings generated