### PR TITLE
fix(packer): centos stream image checksum

### DIFF
--- a/packer/centos/variables.auto.pkrvars.hcl
+++ b/packer/centos/variables.auto.pkrvars.hcl
@@ -1,5 +1,5 @@
 vm_name        = "vbw-centos8"
-iso_url        = "http://mirror.mia.velocihost.net/centos/8-stream/isos/x86_64/CentOS-Stream-8-x86_64-20220525-boot.iso"
+iso_url        = "http://mirror.mia.velocihost.net/centos/8-stream/isos/x86_64/CentOS-Stream-8-x86_64-latest-boot.iso"
 iso_checksum   = "file:http://mirror.mia.velocihost.net/centos/8-stream/isos/x86_64/CHECKSUM"
 ssh_username   = "agayle"
 cpus           = 1


### PR DESCRIPTION
# Description
Fix the CentOS Stream image used by Packer so the checksum works

# Testing methods
N/A

# Checklist:

- [x] The code follows the style guidelines of this project
- [x] The code has been self-reviewed
- [x] The code has been commented, particularly in hard-to-understand areas
- [x] The documentation has updated
- [x] There are no new warnings generated

**Please remove any instructional text before submitting the pull request**

