### PR TITLE
chore(golang): bump to go 1.19.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.18.2
+golang 1.19.4
 k3d 5.4.6
 kubectl 1.24.8
 helm 3.9.4

--- a/golang/book-library/go.mod
+++ b/golang/book-library/go.mod
@@ -1,6 +1,6 @@
 module book-library
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.8.0

--- a/golang/book-library/main.go
+++ b/golang/book-library/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -115,12 +116,21 @@ func HandleHomePage(c *gin.Context) {
 func main() {
 
 	router := gin.Default()
-	router.SetTrustedProxies(nil)
+	err := router.SetTrustedProxies(nil)
+	if err != nil {
+		log.Fatalf("Failed to configure trusted proxies: %v", err)
+	}
+
 	router.GET("/", HandleHomePage)
 	router.GET("/books", GetBooks)
 	router.POST("/books", AddBook)
 	router.GET("/books/:isbn", GetBookByISBN)
 	router.PATCH("/checkout", CheckoutBook)
 	router.PATCH("/return", ReturnBook)
-	router.Run("localhost:8080")
+
+	addr := "localhost:8080"
+	err = router.Run(addr)
+	if err != nil {
+		log.Fatalf("Failed to run router on %v with error %v", addr, err)
+	}
 }

--- a/golang/book-library/main_test.go
+++ b/golang/book-library/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +41,7 @@ func TestHandleHomePage(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
-	responseData, _ := ioutil.ReadAll(w.Body)
+	responseData, _ := io.ReadAll(w.Body)
 
 	assert.Equal(t, res, string(responseData))
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -87,7 +87,8 @@ func TestGetBooks(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	var books []Book
-	json.Unmarshal(w.Body.Bytes(), &books)
+	err := json.Unmarshal(w.Body.Bytes(), &books)
+	assert.Equal(t, err, nil)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.NotEmpty(t, books)


### PR DESCRIPTION
# Description

* Bump go to 1.19.4
* Replace deprecated `ioutil` package
* Add error checking to key main method calls
